### PR TITLE
Proper depth rendering + fixed clone mechanics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
         "twig/twig": "^2.11"
     },
     "require-dev": {
-        "becklyn/php-cs": "^1.4"
+        "becklyn/php-cs": "^1.4",
+        "symfony/css-selector": "^4.3",
+        "symfony/dom-crawler": "^4.3"
     },
     "config": {
         "sort-packages": true

--- a/src/Item/MenuItem.php
+++ b/src/Item/MenuItem.php
@@ -795,7 +795,7 @@ class MenuItem
 
         foreach ($oldChildren as $child)
         {
-            $this->children[] = clone $child;
+            $this->addChild(clone $child);
         }
     }
 

--- a/src/Item/MenuItem.php
+++ b/src/Item/MenuItem.php
@@ -783,6 +783,13 @@ class MenuItem
      */
     public function __clone ()
     {
+        // Remove the parent link when cloning, as it wouldn't even be in the list of children.
+        // If the user wants to add it to the same parent, they can do it themselves.
+        // This has the added bonus that if used with `find()` and rendering, that it will reset
+        // the level calculation on this node.
+        $this->parent = null;
+
+        // Explicitly deep clone children.
         $oldChildren = $this->children;
         $this->children = [];
 

--- a/src/Renderer/MenuRenderer.php
+++ b/src/Renderer/MenuRenderer.php
@@ -5,15 +5,14 @@ namespace Becklyn\Menu\Renderer;
 use Becklyn\Menu\Item\MenuItem;
 use Becklyn\Menu\Visitor\ItemVisitor;
 use Psr\Container\ContainerInterface;
-use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Twig\Environment;
 
-class MenuRenderer implements ServiceSubscriberInterface
+class MenuRenderer
 {
     /**
-     * @var ContainerInterface
+     * @var Environment
      */
-    private $locator;
+    private $twig;
 
 
     /**
@@ -26,9 +25,9 @@ class MenuRenderer implements ServiceSubscriberInterface
      * @param ContainerInterface $locator
      * @param ItemVisitor[]      $visitors
      */
-    public function __construct (ContainerInterface $locator, iterable $visitors)
+    public function __construct (Environment $twig, iterable $visitors)
     {
-        $this->locator = $locator;
+        $this->twig = $twig;
         $this->visitors = $visitors;
     }
 
@@ -70,7 +69,7 @@ class MenuRenderer implements ServiceSubscriberInterface
         // resolve the ancestors
         $root->resolveTree($options["currentClass"], $options["ancestorClass"]);
 
-        return $this->locator->get(Environment::class)->render($template, [
+        return $this->twig->render($template, [
             "options" => $options,
             "root" => $root,
         ]);
@@ -93,16 +92,5 @@ class MenuRenderer implements ServiceSubscriberInterface
         {
             $this->applyVisitors($child);
         }
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public static function getSubscribedServices ()
-    {
-        return [
-            Environment::class,
-        ];
     }
 }

--- a/src/Resources/views/menu.html.twig
+++ b/src/Resources/views/menu.html.twig
@@ -1,10 +1,11 @@
 {% extends "@BecklynMenu/root.html.twig" %}
 
-
-
-
+{#-
+ #  Renders a list of children of the given item.
+ #
+ #  @var \Becklyn\Menu\Item\MenuItem item
+-#}
 {%- block children -%}
-    {#- @var \Becklyn\Menu\Item\MenuItem item -#}
     {%- set children = item.visibleChildren -%}
 
     {%- if children is not empty and (options.depth is null or options.depth > item.level) -%}
@@ -19,8 +20,12 @@
 {%- endblock -%}
 
 
+{#-
+ #  Renders the list item of a single item
+ #
+ #  @var \Becklyn\Menu\Item\MenuItem item
+-#}
 {%- block listItem -%}
-    {#- @var \Becklyn\Menu\Item\MenuItem item -#}
     <li{{ _self.attributes(item.listItemAttributes) }}>
         {{- block("item") -}}
         {{- block("children") -}}
@@ -28,26 +33,42 @@
 {%- endblock -%}
 
 
+{#-
+ #  Renders the content of a single item (link or span basically)
+ #
+ #  @var \Becklyn\Menu\Item\MenuItem item
+-#}
 {%- block item -%}
-    {#- @var \Becklyn\Menu\Item\MenuItem item -#}
     {%- set attributes = item.listItemAttributes -%}
     {{- item.target is not null ? block("linkElement") : block("spanElement") -}}
 {%- endblock -%}
 
 
+{#-
+ #  The content of an item, if it is a link
+ #
+ #  @var \Becklyn\Menu\Item\MenuItem item
+-#}
 {%- block linkElement -%}
-    {#- @var \Becklyn\Menu\Item\MenuItem item -#}
     <a href="{{ item.target }}"{{ _self.attributes(item.linkAttributes) }}>{{ block("label") }}</a>
 {%- endblock -%}
 
 
+{#-
+ #  The content of an item, if it is not a link
+ #
+ #  @var \Becklyn\Menu\Item\MenuItem item
+-#}
 {%- block spanElement -%}
-    {#- @var \Becklyn\Menu\Item\MenuItem item -#}
     <span{{ _self.attributes(item.linkAttributes) }}>{{ block("label") }}</span>
 {%- endblock -%}
 
 
-
+{#-
+ #  The label (textual content) of an item
+ #
+ #  @var \Becklyn\Menu\Item\MenuItem item
+-#}
 {%- block label -%}
     {%- if options.translationDomain is not same as (false) -%}
         {{ item.label | trans([], options.translationDomain) }}
@@ -57,6 +78,11 @@
 {%- endblock -%}
 
 
+{#-
+ #  Renders a list of HTML attributes to a string
+ #
+ #  @var array attributes
+-#}
 {%- macro attributes (attributes) -%}
     {%- for name, value in attributes -%}
         {%- if value is not none and value is not same as(false) -%}

--- a/src/Resources/views/root.html.twig
+++ b/src/Resources/views/root.html.twig
@@ -1,4 +1,5 @@
 {#- @var \Becklyn\Menu\Item\MenuItem root -#}
+{#- @var array options -#}
 
 {%- with {item: root} -%}
     {{- block("children") -}}

--- a/src/Twig/MenuTwigExtension.php
+++ b/src/Twig/MenuTwigExtension.php
@@ -41,7 +41,7 @@ class MenuTwigExtension extends AbstractExtension implements ServiceSubscriberIn
     /**
      * @inheritDoc
      */
-    public function getFunctions ()
+    public function getFunctions () : array
     {
         return [
             new TwigFunction("menu_render", [$this, "renderMenu"], ["is_safe" => ["html"]]),
@@ -52,7 +52,7 @@ class MenuTwigExtension extends AbstractExtension implements ServiceSubscriberIn
     /**
      * @inheritDoc
      */
-    public static function getSubscribedServices ()
+    public static function getSubscribedServices () : array
     {
         return [
             MenuRenderer::class,

--- a/src/Twig/MenuTwigExtension.php
+++ b/src/Twig/MenuTwigExtension.php
@@ -2,24 +2,39 @@
 
 namespace Becklyn\Menu\Twig;
 
+use Becklyn\Menu\Item\MenuItem;
 use Becklyn\Menu\Renderer\MenuRenderer;
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
-class MenuTwigExtension extends AbstractExtension
+class MenuTwigExtension extends AbstractExtension implements ServiceSubscriberInterface
 {
     /**
-     * @var MenuRenderer
+     * @var ContainerInterface
      */
-    private $renderer;
+    private $locator;
 
 
     /**
-     * @param MenuRenderer $renderer
+     * @param ContainerInterface $renderer
      */
-    public function __construct (MenuRenderer $renderer)
+    public function __construct (ContainerInterface $locator)
     {
-        $this->renderer = $renderer;
+        $this->locator = $locator;
+    }
+
+
+    /**
+     * @param MenuItem|null $root
+     * @param array         $options
+     *
+     * @return string
+     */
+    public function renderMenu (?MenuItem $root, array $options = []) : string
+    {
+        return $this->locator->get(MenuRenderer::class)->render($root, $options);
     }
 
 
@@ -29,7 +44,18 @@ class MenuTwigExtension extends AbstractExtension
     public function getFunctions ()
     {
         return [
-            new TwigFunction("menu_render", [$this->renderer, "render"], ["is_safe" => ["html"]]),
+            new TwigFunction("menu_render", [$this, "renderMenu"], ["is_safe" => ["html"]]),
+        ];
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedServices ()
+    {
+        return [
+            MenuRenderer::class,
         ];
     }
 }

--- a/tests/Item/MenuItemTest.php
+++ b/tests/Item/MenuItemTest.php
@@ -77,10 +77,22 @@ class MenuItemTest extends TestCase
         $parent = new MenuItem("parent");
         $child = $parent->createChild("child");
         $grandchild = $child->createChild("grandchild");
+        $youngest = $grandchild->createChild("grandchild");
 
         self::assertSame(0, $parent->getLevel());
         self::assertSame(1, $child->getLevel());
         self::assertSame(2, $grandchild->getLevel());
+        self::assertSame(3, $youngest->getLevel());
+
+        // remove grandchild from the tree and make it a new root
+        $grandchild->setParent(null);
+
+        // these should be unchanged
+        self::assertSame(0, $parent->getLevel());
+        self::assertSame(1, $child->getLevel());
+        // these should start from 0 again
+        self::assertSame(0, $grandchild->getLevel());
+        self::assertSame(1, $youngest->getLevel());
     }
 
 

--- a/tests/Item/MenuItemTest.php
+++ b/tests/Item/MenuItemTest.php
@@ -238,4 +238,40 @@ class MenuItemTest extends TestCase
         self::assertSame($expectedLabels, $actualLabels);
     }
 
+
+    /**
+     *
+     */
+    public function testCloneChildrenReferences () : void
+    {
+        $root = new MenuItem();
+        $root->createChild("test");
+
+        self::assertSame($root, $root->getChildren()[0]->getParent());
+
+        // clone should update the children and leave the old ones intact
+        $clone = clone $root;
+        self::assertSame($clone, $clone->getChildren()[0]->getParent());
+        self::assertSame($root, $root->getChildren()[0]->getParent());
+    }
+
+
+    /**
+     *
+     */
+    public function testCloneParentReferences () : void
+    {
+        $root = new MenuItem();
+        $child = $root->createChild("test");
+
+        self::assertSame($child, $root->getChildren()[0]);
+        self::assertNotNull($child->getParent());
+
+        // clone should update the children and leave the old ones intact
+        $clone = clone $child;
+        self::assertNotSame($clone, $child);
+        // the old relation stays intact
+        self::assertSame($child, $root->getChildren()[0]);
+        self::assertNull($clone->getParent());
+    }
 }

--- a/tests/Renderer/DepthRenderingTest.php
+++ b/tests/Renderer/DepthRenderingTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Becklyn\Menu\Renderer;
+
+use Becklyn\Menu\Item\MenuItem;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+class DepthRenderingTest extends TestCase
+{
+    use RendererTestTrait;
+
+
+    /**
+     *
+     */
+    public function testRendering () : void
+    {
+        $renderer = $this->createRenderer();
+
+        $root = new MenuItem();
+        $root
+            ->createChild("1")
+            ->createChild("1.1")
+            ->createChild("1.1.1")
+            ->createChild("1.1.1.1")
+            ->createChild("1.1.1.1.1");
+
+        $html = $renderer->render($root);
+        $crawler = new Crawler($html);
+
+        self::assertCount(1, $crawler->filter("ul.menu-level-0"));
+        self::assertCount(1, $crawler->filter("ul.menu-level-1"));
+        self::assertCount(1, $crawler->filter("ul.menu-level-2"));
+        self::assertCount(1, $crawler->filter("ul.menu-level-3"));
+        self::assertCount(1, $crawler->filter("ul.menu-level-4"));
+    }
+
+
+    public function testRenderingWithDepth () : void
+    {
+
+        $renderer = $this->createRenderer();
+
+        $root = new MenuItem();
+        $root
+            ->createChild("1")
+            ->createChild("1.1")
+            ->createChild("1.1.1")
+            ->createChild("1.1.1.1")
+            ->createChild("1.1.1.1.1");
+
+        $html = $renderer->render($root, ["depth" => 2]);
+        $crawler = new Crawler($html);
+
+        self::assertCount(1, $crawler->filter("ul.menu-level-0"));
+        self::assertCount(1, $crawler->filter("ul.menu-level-1"));
+        self::assertCount(0, $crawler->filter("ul.menu-level-2"));
+        self::assertCount(0, $crawler->filter("ul.menu-level-3"));
+        self::assertCount(0, $crawler->filter("ul.menu-level-4"));
+    }
+
+
+    public function testRenderingWithDepthNotAtRoot () : void
+    {
+
+        $renderer = $this->createRenderer();
+
+        $root = new MenuItem();
+        $root
+            ->createChild("1")
+            ->createChild("1.1", ["key" => "start"])
+            ->createChild("1.1.1")
+            ->createChild("1.1.1.1")
+            ->createChild("1.1.1.1.1");
+
+        $html = $renderer->render($root->find("start"), ["depth" => 2]);
+        echo($html);
+        $crawler = new Crawler($html);
+
+        self::assertCount(1, $crawler->filter("ul.menu-level-0"), "1 li under root");
+        self::assertCount(1, $crawler->filter("ul.menu-level-1"));
+        self::assertCount(0, $crawler->filter("ul.menu-level-2"));
+        self::assertCount(0, $crawler->filter("ul.menu-level-3"));
+        self::assertCount(0, $crawler->filter("ul.menu-level-4"));
+        self::assertCount(1, $crawler->filter(".menu-list > li > .menu-list"));
+    }
+}

--- a/tests/Renderer/DepthRenderingTest.php
+++ b/tests/Renderer/DepthRenderingTest.php
@@ -75,7 +75,6 @@ class DepthRenderingTest extends TestCase
             ->createChild("1.1.1.1.1");
 
         $html = $renderer->render($root->find("start"), ["depth" => 2]);
-        echo($html);
         $crawler = new Crawler($html);
 
         self::assertCount(1, $crawler->filter("ul.menu-level-0"), "1 li under root");

--- a/tests/Renderer/RendererTestTrait.php
+++ b/tests/Renderer/RendererTestTrait.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Becklyn\Menu\Renderer;
+
+use Becklyn\Menu\Renderer\MenuRenderer;
+use Tests\Becklyn\Menu\Twig\TestTwigMocksExtension;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+trait RendererTestTrait
+{
+    /**
+     * Creates and wires a menu renderer
+     *
+     * @param array $visitors
+     */
+    private function createRenderer (array $visitors = []) : MenuRenderer
+    {
+        $loader = new FilesystemLoader();
+        $loader->addPath(__DIR__ . "/../../src/Resources/views", "BecklynMenu");
+
+        $twig = new Environment($loader, [
+            "auto_reload" => true,
+            "cache" => false,
+            "debug" => true,
+            "strict_variables" => true,
+        ]);
+
+        $twig->addExtension(new TestTwigMocksExtension());
+
+        return new MenuRenderer($twig, $visitors);
+    }
+}

--- a/tests/Twig/TestTwigMocksExtension.php
+++ b/tests/Twig/TestTwigMocksExtension.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Becklyn\Menu\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class TestTwigMocksExtension extends AbstractExtension
+{
+    /**
+     * @param string $id
+     *
+     * @return string
+     */
+    public function trans (string $id, array $parameters = [], string $domain = "messages")
+    {
+        return "TRANS: {$id} (in {$domain})";
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getFilters ()
+    {
+        return [
+            new TwigFilter("trans", [$this, "trans"]),
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | yes                                                               |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | /no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | not required                                 |

<!-- describe your changes below -->
This fixes a few issues when cloning the menu. It also has the added bonus, that rendering a child menu starts with `level-0` again (which makes the structure for styling etc. predictable) and that the depth parameter works again.

This was the last remaining issue for v1.0.