### PR TITLE
Use automatic sorting instead of specifically configuring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.1.0
+=====
+
+*   Removed the `sort` option, the items are now automatically sorted: first desc by priority. 
+    If the priority is the same, then asc by label.
+
+
 1.0.1
 =====
 

--- a/src/Item/MenuItem.php
+++ b/src/Item/MenuItem.php
@@ -127,14 +127,6 @@ class MenuItem
 
 
     /**
-     * The sort method for sorting the children of the item.
-     *
-     * @var string
-     */
-    private $sort = MenuItemSorter::SORT_PRIORITY;
-
-
-    /**
      * The children of the menu item.
      *
      * @var MenuItem[]
@@ -207,11 +199,6 @@ class MenuItem
         if (isset($options["security"]))
         {
             $this->setSecurity($options["security"]);
-        }
-
-        if (isset($options["sort"]))
-        {
-            $this->setSort($options["sort"]);
         }
     }
 
@@ -582,29 +569,6 @@ class MenuItem
     //endregion
 
 
-    //region $this->sort
-    /**
-     * @return string
-     */
-    public function getSort () : string
-    {
-        return $this->sort;
-    }
-
-
-    /**
-     * @param string $sort
-     *
-     * @return MenuItem
-     */
-    public function setSort (string $sort) : self
-    {
-        $this->sort = $sort;
-        return $this;
-    }
-    //endregion
-
-
     //region $this->children
     /**
      * @param string $name
@@ -773,7 +737,7 @@ class MenuItem
         }
 
         // sort children
-        $this->children = MenuItemSorter::sort($this->sort, $this->children);
+        $this->children = MenuItemSorter::sort($this->children);
 
         return $this->current || $isCurrentAncestor;
     }

--- a/src/Sorter/MenuItemSorter.php
+++ b/src/Sorter/MenuItemSorter.php
@@ -2,83 +2,34 @@
 
 namespace Becklyn\Menu\Sorter;
 
-use Becklyn\Menu\Exception\InvalidSortMethodException;
 use Becklyn\Menu\Item\MenuItem;
 
 class MenuItemSorter
 {
-    public const SORT_NONE = "none";
-    public const SORT_PRIORITY = "priority";
-    public const SORT_ALPHA = "alpha";
-
-
     /**
-     * @param string $method
-     * @param array  $items
-     *
-     * @return array
-     */
-    public static function sort (string $method, array $items) : array
-    {
-        if (self::SORT_NONE === $method)
-        {
-            return $items;
-        }
-
-        if (self::SORT_PRIORITY === $method)
-        {
-            return self::stableSortItems(
-                $items,
-                function (MenuItem $item) { return $item->getPriority(); },
-                function (int $left, int $right) { return $right - $left; }
-            );
-        }
-
-        if (self::SORT_ALPHA === $method)
-        {
-            return self::stableSortItems(
-                $items,
-                function (MenuItem $item) { return $item->getLabel() ?? ""; },
-                "strnatcasecmp"
-            );
-        }
-
-
-        throw new InvalidSortMethodException(\sprintf("Unsupported sort method '%s'.", $method));
-    }
-
-    /**
-     * Sorts the children by desc priority (stable).
+     * Sorts the menu items.
      *
      * @param MenuItem[] $items
      *
      * @return MenuItem[]
      */
-    private static function stableSortItems (array $items, callable $valueFetcher, callable $compare) : array
+    public static function sort (array $items) : array
     {
-        $entries = [];
-
-        foreach ($items as $index => $item)
-        {
-            $entries[] = [$index, $valueFetcher($item)];
-        }
-
         \usort(
-            $entries,
-            function (array $left, array $right) use ($compare)
+            $items,
+            function (MenuItem $left, MenuItem $right)
             {
-                // sort desc by priorities. If they are falsy (= 0), then sort asc by key
-                return $compare($left[1], $right[1]) ?: $left[0] - $right[0];
+                // if the same priority -> sort alphabetically asc
+                if ($left->getPriority() === $right->getPriority())
+                {
+                    return \strnatcasecmp((string) $left->getLabel(), (string) $right->getLabel());
+                }
+
+                // order by priority desc by default
+                return $right->getPriority() - $left->getPriority();
             }
         );
 
-        $result = [];
-
-        foreach ($entries as $entry)
-        {
-            $result[] = $items[$entry[0]];
-        }
-
-        return $result;
+        return $items;
     }
 }

--- a/tests/Item/MenuItemTest.php
+++ b/tests/Item/MenuItemTest.php
@@ -32,7 +32,6 @@ class MenuItemTest extends TestCase
             "extras" => $extras,
             "key" => "key",
             "security" => "security",
-            "sort" => MenuItemSorter::SORT_ALPHA,
         ]);
 
         self::assertSame("item", $item->getLabel());
@@ -46,7 +45,6 @@ class MenuItemTest extends TestCase
         self::assertSame($extras, $item->getExtras());
         self::assertSame("key", $item->getKey());
         self::assertSame("security", $item->getSecurity());
-        self::assertSame(MenuItemSorter::SORT_ALPHA, $item->getSort());
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | no                                                                |
| New feature?  | yes <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | debatable                                                               |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | https://github.com/Becklyn-Studios/docs/pull/40                         |

<!-- describe your changes below -->
It is debatable, whether this is a BC break, as technically nothing will break, the order of the items might only be different from before.
I would argue that this change is fine and it is not a BC break.

This new way is superior to the previous implementation, as you can still simulate it by defining different priorities. Also the `none` options was pretty weird and useless, to be honest.