### PR TITLE
Re-introduce sort option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.1.1
+=====
+
+*   Reintroduce the `sort` option, but as boolean flag to toggle the sorting on/off. Default is off.
+
+
 1.1.0
 =====
 

--- a/src/Item/MenuItem.php
+++ b/src/Item/MenuItem.php
@@ -127,6 +127,14 @@ class MenuItem
 
 
     /**
+     * Whether the item should be sorted.
+     *
+     * @var bool
+     */
+    private $sort = false;
+
+
+    /**
      * The children of the menu item.
      *
      * @var MenuItem[]
@@ -199,6 +207,11 @@ class MenuItem
         if (isset($options["security"]))
         {
             $this->setSecurity($options["security"]);
+        }
+
+        if (isset($options["sort"]))
+        {
+            $this->setSort((bool) $options["sort"]);
         }
     }
 
@@ -569,6 +582,29 @@ class MenuItem
     //endregion
 
 
+    //region $this->sort
+    /**
+     * @return bool
+     */
+    public function getSort () : bool
+    {
+        return $this->sort;
+    }
+
+
+    /**
+     * @param bool $sort
+     *
+     * @return MenuItem
+     */
+    public function setSort (bool $sort) : self
+    {
+        $this->sort = $sort;
+        return $this;
+    }
+    //endregion
+
+
     //region $this->children
     /**
      * @param string $name
@@ -737,7 +773,10 @@ class MenuItem
         }
 
         // sort children
-        $this->children = MenuItemSorter::sort($this->children);
+        if ($this->sort)
+        {
+            $this->children = MenuItemSorter::sort($this->children);
+        }
 
         return $this->current || $isCurrentAncestor;
     }

--- a/tests/Item/MenuItemTest.php
+++ b/tests/Item/MenuItemTest.php
@@ -32,6 +32,7 @@ class MenuItemTest extends TestCase
             "extras" => $extras,
             "key" => "key",
             "security" => "security",
+            "sort" => true,
         ]);
 
         self::assertSame("item", $item->getLabel());
@@ -45,6 +46,7 @@ class MenuItemTest extends TestCase
         self::assertSame($extras, $item->getExtras());
         self::assertSame("key", $item->getKey());
         self::assertSame("security", $item->getSecurity());
+        self::assertSame(true, $item->getSort());
     }
 
 
@@ -251,5 +253,37 @@ class MenuItemTest extends TestCase
         // the old relation stays intact
         self::assertSame($child, $root->getChildren()[0]);
         self::assertNull($clone->getParent());
+    }
+
+
+    /**
+     *
+     */
+    public function testWithSort () : void
+    {
+        $root = new MenuItem(null, ["sort" => true]);
+        $root->createChild("y");
+        $root->createChild("z");
+        $root->createChild("x");
+        $root->resolveTree();
+
+        $labels = \array_map(function (MenuItem $item) { return $item->getLabel(); }, $root->getChildren());
+        self::assertSame(["x", "y", "z"], $labels);
+    }
+
+
+    /**
+     *
+     */
+    public function testWithoutSort () : void
+    {
+        $root = new MenuItem(null);
+        $root->createChild("y");
+        $root->createChild("z");
+        $root->createChild("x");
+        $root->resolveTree();
+
+        $labels = \array_map(function (MenuItem $item) { return $item->getLabel(); }, $root->getChildren());
+        self::assertSame(["y", "z", "x"], $labels);
     }
 }


### PR DESCRIPTION
But only on/off, no type of sorting

| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | https://github.com/Becklyn-Studios/docs/pull/40 <!-- insert URL here -->                                  |

<!-- describe your changes below -->
This partially reverts the last PR. It is useful to have an on/off switch for menus.