### PR TITLE
Fix block name typo in base theme + Optimize the menu template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.1.2
+=====
+
+*   (bug) Fix block name typo in base theme.
+*   (improvement) Optimize the menu template.
+
 2.1.1
 =====
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,12 @@
+2.x to 2.1.1
+============
+
+*   The template block `text_element` was renamed to `text_item`.
+*   The template block `text_element_wrap` was removed. It was merged into `item`.
+*   The template block `link_item_wrap` was removed. It was merged into `item`.
+*   The `attributes` in template block `item_wrap` no correctly the link attributes instead of the list item attributes.  
+
+
 1.x to 2.0
 ==========
 

--- a/src/Resources/views/menu.html.twig
+++ b/src/Resources/views/menu.html.twig
@@ -85,7 +85,7 @@
  #  @var \Becklyn\Menu\Item\MenuItem item
 -#}
 {%- block item_wrap -%}
-    {%- set attributes = item.listItemAttributes -%}
+    {%- set attributes = item.linkAttributes -%}
     {%- set target = item.target -%}
 
     {{- block("item") -}}
@@ -95,34 +95,24 @@
 {#-
  #  Renders the content of a single item (link or span basically)
  #
+ #  @var array attributes
  #  @var string|null target
  #  @var \Becklyn\Menu\Item\MenuItem item
 -#}
 {%- block item -%}
-    {{- target is not null ? block("link_item_wrap") : block("text_element_wrap") -}}
+    {{- target is not null ? block("link_item") : block("text_item") -}}
 {%- endblock item -%}
 
 
 {# ------------------------------------------------------------------------------------------------------------------ #}
 {# Link item (<a>) #}
 {# ------------------------------------------------------------------------------------------------------------------ #}
-{#-
- #  WrapperThe content of an item, if it is a link
- #
- #  @var string|null target
- #  @var \Becklyn\Menu\Item\MenuItem item
--#}
-{%- block link_item_wrap -%}
-    {%- set attributes = item.linkAttributes -%}
-
-    {{- block("link_item") -}}
-{%- endblock link_item_wrap -%}
 
 {#-
  #  The content of an item, if it is a link
  #
  #  @var array attributes
- #  @var string|null target
+ #  @var string target
  #  @var \Becklyn\Menu\Item\MenuItem item
 -#}
 {%- block link_item -%}
@@ -133,16 +123,6 @@
 {# ------------------------------------------------------------------------------------------------------------------ #}
 {# Text item (<span>) #}
 {# ------------------------------------------------------------------------------------------------------------------ #}
-{#-
- #  The content of an item, if it is not a link
- #
- #  @var \Becklyn\Menu\Item\MenuItem item
--#}
-{%- block text_element_wrap -%}
-    {%- set attributes = item.linkAttributes -%}
-
-    {{- block("text_element") -}}
-{%- endblock -%}
 
 {#-
  #  The content of an item, if it is not a link
@@ -150,7 +130,7 @@
  #  @var array attributes
  #  @var \Becklyn\Menu\Item\MenuItem item
 -#}
-{%- block text_element -%}
+{%- block text_item -%}
     <span{{ _self.attributes(attributes) }}>{{ block("label") }}</span>
 {%- endblock -%}
 


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | technically yes |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->
Technically this is a BC break, however the newest version isn't used enough in the wild, as well as this was never intended to be like this anyway (so it is rather a bug).