### PR TITLE
Made `$name` in `MenuItem::createChild()` nullable + Added empty defa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+2.1.3
+=====
+
+*   (improvement) Made `$name` in `MenuItem::createChild()` nullable.
+*   (improvement) Added empty default state for `current` in MenuItems.
+ 
+
 2.1.2
 =====
 

--- a/src/Item/MenuItem.php
+++ b/src/Item/MenuItem.php
@@ -121,9 +121,9 @@ class MenuItem
     /**
      * Whether the item is the currently selected menu item.
      *
-     * @var bool
+     * @var bool|null
      */
-    private $current = false;
+    private $current;
 
 
     /**
@@ -544,7 +544,7 @@ class MenuItem
      */
     public function isCurrent () : bool
     {
-        return $this->current;
+        return true === $this->current;
     }
 
 
@@ -555,6 +555,14 @@ class MenuItem
     {
         $this->current = $current;
         return $this;
+    }
+
+
+    /**
+     */
+    public function hasCurrentSet () : bool
+    {
+        return null !== $this->current;
     }
     //endregion
 
@@ -590,9 +598,9 @@ class MenuItem
     //region $this->children
     /**
      */
-    public function createChild (string $name, array $options = []) : self
+    public function createChild (?string $label = null, array $options = []) : self
     {
-        $child = new self($name, $options);
+        $child = new self($label, $options);
         $child->parent = $this;
         $this->children[] = $child;
 

--- a/src/Visitor/VoterVisitor.php
+++ b/src/Visitor/VoterVisitor.php
@@ -26,8 +26,8 @@ class VoterVisitor implements ItemVisitor
      */
     public function visit (MenuItem $item, array $options) : void
     {
-        // only apply voters if the item isn't yet marked as "current" from the construction
-        if (!$item->isCurrent())
+        // only apply voters if the item isn't yet marked as anything from the construction
+        if (!$item->hasCurrentSet())
         {
             foreach ($this->voters as $voter)
             {


### PR DESCRIPTION
…ult state for `current` in MenuItems

| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->
