### PR TITLE
add possibility to simply add parameters to a LazyRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+next-minor
+==========
+*   (improvement) Added `LazyRoute::withParameters()` to simplify adding parameters.
+
+
 3.0.0
 =====
 

--- a/src/Target/LazyRoute.php
+++ b/src/Target/LazyRoute.php
@@ -99,7 +99,8 @@ class LazyRoute
 
         foreach ($parameters as $key => $value)
         {
-            $normalized[$key] = \method_exists($value, "getId")
+            // automatically integrate with entities, so that you can just pass the entity and it will automatically use its id
+            $normalized[$key] = \is_object($value) && \method_exists($value, "getId")
                 ? $value->getId()
                 : $value;
         }

--- a/src/Target/LazyRoute.php
+++ b/src/Target/LazyRoute.php
@@ -77,4 +77,33 @@ class LazyRoute
     {
         return $urlGenerator->generate($this->route, $this->parameters, $this->referenceType);
     }
+
+
+    /**
+     * @return static
+     */
+    public function withParameters (array $parameters) : self
+    {
+        $modified = clone $this;
+        $modified->parameters = \array_replace($modified->parameters, $this->normalizeParameters($parameters));
+        return $modified;
+    }
+
+
+    /**
+     * Normalizes the parameters
+     */
+    private function normalizeParameters (array $parameters) : array
+    {
+        $normalized = [];
+
+        foreach ($parameters as $key => $value)
+        {
+            $normalized[$key] = \method_exists($value, "getId")
+                ? $value->getId()
+                : $value;
+        }
+
+        return $normalized;
+    }
 }

--- a/src/Target/LazyRoute.php
+++ b/src/Target/LazyRoute.php
@@ -39,7 +39,7 @@ class LazyRoute
     public function __construct (string $route, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         $this->route = $route;
-        $this->parameters = $parameters;
+        $this->parameters = $this->normalizeParameters($parameters);
         $this->referenceType = $referenceType;
     }
 

--- a/tests/Item/MenuItem/MenuItemAncestorsTest.php
+++ b/tests/Item/MenuItem/MenuItemAncestorsTest.php
@@ -50,6 +50,8 @@ class MenuItemAncestorsTest extends TestCase
         self::assertSame($child, $parent2->getChildren()[0]);
         self::assertSame($parent2, $child->getParent());
     }
+
+
     /**
      *
      */

--- a/tests/Target/LazyRoute/LazyRouteGenerateTest.php
+++ b/tests/Target/LazyRoute/LazyRouteGenerateTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Becklyn\Menu\Target\LazyRoute;
+
+use Becklyn\Menu\Target\LazyRoute;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class LazyRouteGenerateTest extends TestCase
+{
+    /**
+     * Tests basic generation
+     */
+    public function testGenerate () : void
+    {
+        $router = $this->getMockBuilder(RouterInterface::class)
+            ->getMock();
+
+        $router
+            ->expects(self::once())
+            ->method("generate")
+            ->with("route_name", ["param1" => "a", "param2" => "b"], UrlGeneratorInterface::NETWORK_PATH)
+            ->willReturn("result");
+
+        $route = new LazyRoute("route_name", ["param1" => "a", "param2" => "b"], UrlGeneratorInterface::NETWORK_PATH);
+        $route->generate($router);
+    }
+}

--- a/tests/Target/LazyRoute/LazyRouteGenerateTest.php
+++ b/tests/Target/LazyRoute/LazyRouteGenerateTest.php
@@ -24,6 +24,7 @@ class LazyRouteGenerateTest extends TestCase
             ->willReturn("result");
 
         $route = new LazyRoute("route_name", ["param1" => "a", "param2" => "b"], UrlGeneratorInterface::NETWORK_PATH);
-        $route->generate($router);
+
+        self::assertSame("result", $route->generate($router));
     }
 }

--- a/tests/Target/LazyRoute/LazyRouteWithParametersTest.php
+++ b/tests/Target/LazyRoute/LazyRouteWithParametersTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Becklyn\Menu\Target\LazyRoute;
+
+use Becklyn\Menu\Target\LazyRoute;
+use PHPUnit\Framework\TestCase;
+
+class LazyRouteWithParametersTest extends TestCase
+{
+    /**
+     * @return iterable
+     */
+    public function provideCloneWithParameters () : iterable
+    {
+        yield "simple merge" => [
+            ["p1" => "a", "p2" => "b"],
+            ["p3" => "c"],
+            ["p1" => "a", "p2" => "b", "p3" => "c"]
+        ];
+
+        yield "overwrite" => [
+            ["p1" => "a", "p2" => "b"],
+            ["p3" => "c", "p1" => "d"],
+            ["p1" => "d", "p2" => "b", "p3" => "c"]
+        ];
+
+        yield "overwrite with null" => [
+            ["p1" => "a"],
+            ["p1" => null],
+            ["p1" => null]
+        ];
+    }
+
+
+    /**
+     * @dataProvider provideCloneWithParameters
+     */
+    public function testWithParameters (array $paramsBefore, array $paramsWith, array $expected) : void
+    {
+        $route1 = new LazyRoute("route_name", $paramsBefore);
+        $route2 = $route1->withParameters($paramsWith);
+
+        // parameters stay unchanged
+        self::assertEquals($paramsBefore, $route1->getParameters());
+        // check expected result parameters
+        self::assertEquals($expected, $route2->getParameters());
+    }
+}

--- a/tests/Target/LazyRouteTest.php
+++ b/tests/Target/LazyRouteTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Becklyn\RadBundle\Route;
+
+use Becklyn\Menu\Target\LazyRoute;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class LazyRouteTest extends TestCase
+{
+    /**
+     * @return iterable
+     */
+    public function provideCloneWithParameters () : iterable
+    {
+        yield "simple merge" => [
+            ["p1" => "a", "p2" => "b"],
+            ["p3" => "c"],
+            ["p1" => "a", "p2" => "b", "p3" => "c"]
+        ];
+
+        yield "overwrite" => [
+            ["p1" => "a", "p2" => "b"],
+            ["p3" => "c", "p1" => "d"],
+            ["p1" => "d", "p2" => "b", "p3" => "c"]
+        ];
+
+        yield "overwrite with null" => [
+            ["p1" => "a"],
+            ["p1" => null],
+            ["p1" => null]
+        ];
+    }
+
+
+    /**
+     * Tests automatic entity interface support
+     */
+    public function testEntityInterfaceSupport () : void
+    {
+        $entity = new class
+        {
+            public function getId () : ?int { return 123; }
+        };
+
+        $route = new LazyRoute("route_name", ["page" => $entity]);
+
+        $router = $this->getMockBuilder(RouterInterface::class)
+            ->getMock();
+
+        $router
+            ->expects(self::once())
+            ->method("generate")
+            ->with("route_name", ["page" => 123])
+            ->willReturn("result");
+
+        $route->generate($router);
+    }
+
+
+    /**
+     * Tests that entity interfaces are also supported when using `withParameters()`
+     */
+    public function testEntityInterfaceSupportWhenCloning () : void
+    {
+        $entity1 = new class
+        {
+            public function getId () : ?int { return 123; }
+        };
+
+        $entity2 = new class
+        {
+            public function getId () : ?int { return 234; }
+        };
+
+        $route1 = new LazyRoute("route_name", ["page" => $entity1]);
+
+        $router = $this->getMockBuilder(RouterInterface::class)
+            ->getMock();
+
+        $router
+            ->expects(self::exactly(2))
+            ->method("generate")
+            ->withConsecutive(
+                ["route_name", ["page" => 123]],
+                ["route_name", ["page" => 234]]
+            )
+            ->willReturn("result");
+
+        $route1->generate($router);
+
+        $route2 = $route1->withParameters(["page" => $entity2]);
+        $route2->generate($router);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | yes                   |
| Improvement?  | no  |
| Bug fix?      | no                                                                |
| Deprecations? | no   |

Add `LazyRoute::withParameters()` to simplify adding parameters.
